### PR TITLE
Added a warning message

### DIFF
--- a/R/get_cv.R
+++ b/R/get_cv.R
@@ -169,6 +169,12 @@ get_cv_fitted <- function(new_b, d, alpha, the_kernel, lugsail){
 #' get_cv(0.1, d = 3, alpha = 0.05)
 get_cv <- function(new_b, d = 1, alpha = 0.05, the_kernel = "Bartlett",
                    lugsail = "Mother", method = "simulated"){
+
+  if(d >12 & method != "analytical"){
+    method = "analytical"
+    warning("More than 12 coefficients are used. Only the `analytical` critical value is supported for this many dimensions. Method was switched to `analytical`.")
+  }
+
   if(method == "simulated"){
     cv_by_b <- get_cv_simulated(new_b, d, alpha, the_kernel, lugsail)
   }

--- a/R/robust_lm.R
+++ b/R/robust_lm.R
@@ -56,6 +56,11 @@
 p_values <- function(test_stat, the_b = 0, the_d = 1,  the_kernel = "Bartlett",
                      lugsail = "Mother", method = "simulated"){
 
+  if(the_d >12 & method != "analytical"){
+    method = "analytical"
+    warning("More than 12 coefficients are used. Only the `analytical` critical value is supported for this many dimensions. Method was switched to `analytical`.")
+  }
+
   # Get the appropriate CVs
   CV_01  <- get_cv(the_b, the_d, 0.01, the_kernel, lugsail, method)*the_d
   CV_025 <- get_cv(the_b, the_d, 0.025, the_kernel, lugsail, method)*the_d


### PR DESCRIPTION
If user tried a model with more than 12 coefficients, it automatically switched the method to analytical because that is too many variables for the other methods to support.