### PR TITLE
Minor Updates

### DIFF
--- a/R/estimate_LRV.R
+++ b/R/estimate_LRV.R
@@ -115,14 +115,14 @@ LRV_estimator <- function(b, all_autocovariances,
   omega_mother <- LRV_mother_estimator(b, all_autocovariances, the_kernel,
                                        big_T = big_T, d=ncol(all_autocovariances))
   # Mother Kernel
-  if(lugsail_type == "Mother"){
+  if(lugsail_type == "mother"){
     omega <- omega_mother
     corrected_rates <- NA
   }
 
   # Zero Lugsail
-  else if(lugsail_type == "Zero" || lugsail_type == "zero"){
-    lug_para <- get_lugsail_parameters(big_T, q = q, method = "Zero")
+  else if(lugsail_type == "zero"){
+    lug_para <- get_lugsail_parameters(big_T, q = q, method = "zero")
     omega <- LRV_lugsail_estimator(b, all_autocovariances,
                                 the_kernel = the_kernel,
                                 lugsail_parameters = lug_para,
@@ -134,9 +134,9 @@ LRV_estimator <- function(b, all_autocovariances,
   }
 
   # Over Lugsail
-  else if (lugsail_type == "Over"){
+  else if (lugsail_type == "over"){
     # Over Lugsail
-    lug_para <- get_lugsail_parameters(big_T, q = q, method = "Over")
+    lug_para <- get_lugsail_parameters(big_T, q = q, method = "over")
     omega <- LRV_lugsail_estimator(b, all_autocovariances,
                                    the_kernel = the_kernel,
                                    lugsail_parameters = lug_para,

--- a/R/get_b.R
+++ b/R/get_b.R
@@ -55,8 +55,11 @@ b_rule <- function(rho, big_T, alpha, d, w_q, g_q, q=1, tau = NA, auto_adjust = 
 #' @keywords internal
 #' @noRd
 get_tau <- function(alpha = 0.05, lugsail, big_T, rho, d){
+  # ------- Convert string inputs to lowercase -------
+  lugsail <- tolower(lugsail)
+
   # ------- If tau uses default -------
-  if(lugsail == "Zero"){
+  if(lugsail == "zero"){
     tau <- -alpha^(0.5*d)/(big_T *log(abs(rho)))
   } else{
     tau <- alpha*.15
@@ -107,6 +110,10 @@ get_tau <- function(alpha = 0.05, lugsail, big_T, rho, d){
 get_b <- function(the_data, alpha = 0.05, the_kernel ="Bartlett", lugsail="Mother",
                   tau = NA, auto_adjust = T){
 
+  # ------- Convert string inputs to lowercase -------
+  the_kernel <- tolower(the_kernel)
+  lugsail <- tolower(lugsail)
+
   # dimensions
   if(!("matrix" %in% class(the_data))){
     the_data <- as.matrix(the_data)
@@ -122,7 +129,7 @@ get_b <- function(the_data, alpha = 0.05, the_kernel ="Bartlett", lugsail="Mothe
   }
   rho <- mean(all_rhos)
 
-  if(rho <= 0 & lugsail != "Mother"){
+  if(rho <= 0 & lugsail != "mother"){
     warning(paste("Correlation coefficient ", round(rho, 3), "is negative. Mother lugsail settings are recommended."))
   }
 
@@ -146,20 +153,20 @@ get_b <- function(the_data, alpha = 0.05, the_kernel ="Bartlett", lugsail="Mothe
 
 
   # g_q based on lugsail type
-  g_q <- g_q[[tolower(the_kernel)]]
-  if(lugsail == "Zero"){
+  g_q <- g_q[[the_kernel]]
+  if(lugsail == "zero"){
     g_q <- 0
-  } else if (lugsail == "Over"){
+  } else if (lugsail == "over"){
     g_q <- -g_q
   }
 
-  if(lugsail == "Mother"){
+  if(lugsail == "mother"){
     if(tau < 0.1*alpha){
       warning("Recommended tolerance level for mother setttings is 0.1*alpha or higher.")
     }
   }
 
-  if(lugsail == "Over"){
+  if(lugsail == "over"){
     if(rho <0.9 | big_T <200){
       warning("Over lugsail is not recommended for small data sets, or data sets with low correlation.")
     }

--- a/R/get_cv.R
+++ b/R/get_cv.R
@@ -3,31 +3,31 @@
 # Analytical CV -----------------------------------------------------------
 
 
-c1 <- list(Bartlett = list(Mother = 1, Zero = 1.5, Over = 5/3),
-           Parzen = list(Mother = 0.75, Zero = .875, Over = 0.875),
-           TH = list(Mother = 1, Zero = 7/6, Over = 7/6),
-           QS = list(Mother = 5/4, Zero = 1.631486, Over = 1.550773))
+c1 <- list(bartlett = list(mother = 1, zero = 1.5, over = 5/3),
+           parzen = list(mother = 0.75, zero = .875, over = 0.875),
+           th = list(mother = 1, zero = 7/6, over = 7/6),
+           qs = list(mother = 5/4, zero = 1.631486, over = 1.550773))
 
 #' @keywords internal
 #' @noRd
-c2 <- list(Bartlett = list(Mother = 2/3, Zero = 4/3, Over = 1.7037037),
-           Parzen = list(Mother = 151/280, Zero = 0.6877976, Over = 0.7050182),
-           TH = list(Mother = 3/4, Zero = 0.9641497, Over = 0.9864201),
-           QS = list(Mother = 1, Zero = 1.6912606, Over = 1.5342612))
+c2 <- list(bartlett = list(mother = 2/3, zero = 4/3, over = 1.7037037),
+           parzen = list(mother = 151/280, zero = 0.6877976, over = 0.7050182),
+           th = list(mother = 3/4, zero = 0.9641497, over = 0.9864201),
+           qs = list(mother = 1, zero = 1.6912606, over = 1.5342612))
 
 #' @keywords internal
 #' @noRd
-c3 <- list(Bartlett = list(Mother = -1/3, Zero = -0.583333, Over = -0.6296296),
-           Parzen = list(Mother = -7/40, Zero = -0.21875, Over = -0.21389),
-           TH = list(Mother = -0.297358, Zero = -0.371697, Over = -0.3634371),
-           QS = list(Mother = -0.4221716, Zero = -0.5555723, Over = -0.4908948))
+c3 <- list(bartlett = list(mother = -1/3, zero = -0.583333, over = -0.6296296),
+           parzen = list(mother = -7/40, zero = -0.21875, over = -0.21389),
+           th = list(mother = -0.297358, zero = -0.371697, over = -0.3634371),
+           qs = list(mother = -0.4221716, zero = -0.5555723, over = -0.4908948))
 
 #' @keywords internal
 #' @noRd
-c4 <- list(Bartlett = list(Mother = -1/6, Zero = -0.2166667, Over = -0.3271605),
-           Parzen = list(Mother = -0.09196, Zero = -0.1340402 , Over = -0.1332445),
-           TH = list(Mother = -0.172358, Zero = -0.2538967, Over = -0.2511288),
-           QS = list(Mother = -0.3166412, Zero = -0.5454080, Over = -0.4908948))
+c4 <- list(bartlett = list(mother = -1/6, zero = -0.2166667, over = -0.3271605),
+           parzen = list(mother = -0.09196, zero = -0.1340402 , over = -0.1332445),
+           th = list(mother = -0.172358, zero = -0.2538967, over = -0.2511288),
+           qs = list(mother = -0.3166412, zero = -0.5454080, over = -0.4908948))
 
 #' @keywords internal
 #' @noRd
@@ -85,6 +85,16 @@ get_cv_simulated <- function(new_b, d, alpha, the_kernel, lugsail){
   alpha <- paste(0, alpha*100, sep = "")
   if(alpha == "010") alpha <- "10"
   if(alpha == "02.5") alpha <- "025"
+  # Match data file naming conventions
+  if(the_kernel == "qs"){
+    the_kernel <- "QS"
+  } else if(the_kernel == "th"){
+    the_kernel <- "TH"
+  } else {
+    # Capitalize first letter for Bartlett and Parzen
+    the_kernel <- paste0(toupper(substring(the_kernel, 1, 1)), substring(the_kernel, 2))
+  }
+  lugsail <- paste0(toupper(substring(lugsail, 1, 1)), substring(lugsail, 2))
   file <- paste(the_kernel, lugsail, alpha, "Master", sep = "_")
   the_table <- eval(parse(text=file))
 
@@ -111,6 +121,17 @@ get_cv_fitted <- function(new_b, d, alpha, the_kernel, lugsail){
   #the_fits <- readRDS("fitted_CV.rds")
   the_fits <- fitted_CV #eval(parse(text= hi))
   chisq_cv <-  qchisq(1-alpha, df = d)/d
+
+  # Match data file naming conventions
+  if(the_kernel == "qs"){
+    the_kernel <- "QS"
+  } else if(the_kernel == "th"){
+    the_kernel <- "TH"
+  } else {
+    # Capitalize first letter for Bartlett and Parzen
+    the_kernel <- paste0(toupper(substring(the_kernel, 1, 1)), substring(the_kernel, 2))
+  }
+  lugsail <- paste0(toupper(substring(lugsail, 1, 1)), substring(lugsail, 2))
 
   # Pull out only the values you need
   index <- the_fits$kernel == the_kernel & the_fits$lugsail == lugsail &
@@ -169,6 +190,11 @@ get_cv_fitted <- function(new_b, d, alpha, the_kernel, lugsail){
 #' get_cv(0.1, d = 3, alpha = 0.05)
 get_cv <- function(new_b, d = 1, alpha = 0.05, the_kernel = "Bartlett",
                    lugsail = "Mother", method = "simulated"){
+
+  # ------- Convert string inputs to lowercase -------
+  the_kernel <- tolower(the_kernel)
+  lugsail <- tolower(lugsail)
+  method <- tolower(method)
 
   if(d >12 & method != "analytical"){
     method = "analytical"

--- a/R/lugsail.R
+++ b/R/lugsail.R
@@ -29,11 +29,14 @@ lugsail_fct <- function(x, lugsail_parameters, the_kernel= bartlett){
 get_lugsail_parameters <- function(big_T, q, method = "Zero",
                                    b = 0.75*big_T^(-2*q/(2*q+1))){
 
-  if(method == "Over"){
+  # ------- Convert string input to lowercase -------
+  method <- tolower(method)
+
+  if(method == "over"){
     r <- 3
     c <- 2/(1+r^q)
 
-  } else if(method == "Adaptive"){
+  } else if(method == "adaptive"){
     r <- 2
     M  <- big_T * b
     c_num <- (log(big_T) - log(M) + 1)

--- a/R/robust_lm.R
+++ b/R/robust_lm.R
@@ -144,16 +144,21 @@ robust_lm <- function(fit, the_kernel = "Bartlett", lugsail= "Mother",
                       method = "simulated", tau = NA, alpha = 0.05,
                       conf.level = F){
 
+  # ------- Convert string inputs to lowercase -------
+  the_kernel <- tolower(the_kernel)
+  lugsail <- tolower(lugsail)
+  method <- tolower(method)
+
   # ------- Basic statistics needed from the LM object -------
   kernel_fct <- bartlett
   q <- 1
-  if(the_kernel == "QS"){
+  if(the_kernel == "qs"){
     kernel_fct <- qs
     q <- 2
-  } else if(the_kernel == "TH"){
+  } else if(the_kernel == "th"){
     kernel_fct <- th
     q <- 2
-  } else if(the_kernel == "Parzen"){
+  } else if(the_kernel == "parzen"){
     kernel_fct <- parzen
     q <- 2
   }
@@ -183,7 +188,7 @@ robust_lm <- function(fit, the_kernel = "Bartlett", lugsail= "Mother",
     adf_results <- suppressWarnings(tseries::adf.test(errors[,i]))
     statistic[i] <- adf_results$statistic
     parameter[i] <- adf_results$parameter
-    p.value[i] <- adf_results$p.value
+    p.value[i] <- round(adf_results$p.value, digits = 3)
     if(p.value[i]<=0.01){
       p.value[i] <- "<=0.01"
     }

--- a/R/robust_lm.R
+++ b/R/robust_lm.R
@@ -205,6 +205,7 @@ robust_lm <- function(fit, the_kernel = "Bartlett", lugsail= "Mother",
     }
   }
   adf <- data.frame(statistic, parameter, conclusion, p.value)
+  rownames(adf) <- colnames(X)
 
   # ------- AutoCovariance Matrices  -------
   # [#, ] the lag (0, ..., big_T-1)


### PR DESCRIPTION
This PR addresses:
* Rounds P-values from ADF test to 3 decimals.
* ADF output shows column names.
* Inputs to `robust_lm()` are no longer case sensitive via `tolower()`
* Update minor changes to example code for above bullet.