### PR TITLE
Updating Description and Examples

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,9 +9,8 @@ Authors@R: c(
 Maintainer: Rebecca Kurtz-Garcia  <rkurtzgarcia@smith.edu>
 Description: Provides functions for computing fixed-b critical values and
     conducting robust inference procedures for time series data with unknown
-    correlation structures. Implements long-run variance (LRV) estimators
-    using various kernel functions (Bartlett, Parzen, Tukey-Hanning,
-    Quadratic Spectral) and lugsail transformations for improved
+    correlation structures. Implements long-run variance estimators
+    using various kernel functions and lugsail transformations for improved
     finite-sample properties.
 License: GPL (>= 3)
 Encoding: UTF-8

--- a/R/generate_cv.R
+++ b/R/generate_cv.R
@@ -484,7 +484,7 @@ generate_cv_multi <- function(b, d = 2, alpha = 0.05,
 #' # Multiple b's and alpha's
 #' set.seed(62)
 #' CVs <- generate_cv(b = c(0.005, 0.006), d=1, alpha = c(0.05, 0.01),
-#' num_replicates = 1000)
+#' num_replicates = 100)
 #' CVs
 #' # Custom kernel function
 #' my_kernel <- function(x){
@@ -492,7 +492,7 @@ generate_cv_multi <- function(b, d = 2, alpha = 0.05,
 #'   return(k_x)
 #' }
 #' CVs <- generate_cv(b = 0.005, d=1, alpha = 0.05, the_kernel = my_kernel,
-#'  q = 2, num_replicates = 1000)
+#'  q = 2, num_replicates = 100)
 #' CVs
 
 

--- a/man/fixedCV-package.Rd
+++ b/man/fixedCV-package.Rd
@@ -6,7 +6,7 @@
 \alias{fixedCV-package}
 \title{fixedCV: Fixed-b Critical Values for Robust Inference with Time Series Data}
 \description{
-Provides functions for computing fixed-b critical values and conducting robust inference procedures for time series data with unknown correlation structures. Implements long-run variance (LRV) estimators using various kernel functions (Bartlett, Parzen, Tukey-Hanning, Quadratic Spectral) and lugsail transformations for improved finite-sample properties.
+Provides functions for computing fixed-b critical values and conducting robust inference procedures for time series data with unknown correlation structures. Implements long-run variance estimators using various kernel functions and lugsail transformations for improved finite-sample properties.
 }
 \details{
 The main functionality of \code{fixedCV} includes:

--- a/man/generate_cv.Rd
+++ b/man/generate_cv.Rd
@@ -65,7 +65,7 @@ Both package kernels and user supplied kernels maybe supplied. It is not recomme
 # Multiple b's and alpha's
 set.seed(62)
 CVs <- generate_cv(b = c(0.005, 0.006), d=1, alpha = c(0.05, 0.01),
-num_replicates = 1000)
+num_replicates = 100)
 CVs
 # Custom kernel function
 my_kernel <- function(x){
@@ -73,6 +73,6 @@ my_kernel <- function(x){
   return(k_x)
 }
 CVs <- generate_cv(b = 0.005, d=1, alpha = 0.05, the_kernel = my_kernel,
- q = 2, num_replicates = 1000)
+ q = 2, num_replicates = 100)
 CVs
 }


### PR DESCRIPTION
- Updated the description to not have LRV, or the explicit names of the kernels. These were flagged as typos in CRAN submission.

- Also changed the examples in generate_cv() function because they were taking too long to run.